### PR TITLE
🎯 fix: Activation dependency error with PDF Invoices for WC v3.9.0

### DIFF
--- a/dokan-invoice.php
+++ b/dokan-invoice.php
@@ -57,6 +57,15 @@ class Dokan_Invoice {
     private $depends_on       = array();
     private $dependency_error = array();
 
+	/**
+	 * WC PDF Plugin Class Name.
+	 *
+	 * @since 1.2.3
+	 *
+	 * @var string
+	 */
+	public $wc_pdf_class = '';
+
     /**
      * Constructor for the Dokan_Invoice class
      *
@@ -73,13 +82,15 @@ class Dokan_Invoice {
         self::$plugin_url      = plugin_dir_url( self::$plugin_basename );
         self::$plugin_path     = trailingslashit( dirname( __FILE__ ) );
 
+	    $this->wc_pdf_class = version_compare( get_option( 'wpo_wcpdf_version', false ), '3.9.0', '<' ) ? 'WooCommerce_PDF_Invoices' : 'WPO_WCPDF' ;
+
         $this->depends_on['dokan'] = array(
             'name'   => 'WeDevs_Dokan',
             'notice' => sprintf( esc_html__( '<b>Dokan PDF Invoice </b> requires %sDokan plugin%s to be installed & activated!' , 'dokan-invoice' ), '<a target="_blank" href="https://dokan.co/wordpress/">', '</a>' ),
         );
 
         $this->depends_on['woocommerce_pdf_invoices'] = array(
-            'name'   => 'WPO_WCPDF',
+            'name'   => $this->wc_pdf_class,
             'notice' => sprintf( esc_html__( '<b>Dokan PDF Invoice </b> requires %sWooCommerce PDF Invoices & packing slips plugin%s to be installed & activated!' , 'dokan-invoice' ), '<a target="_blank" href="https://wordpress.org/plugins/woocommerce-pdf-invoices-packing-slips/">', '</a>' ),
         );
 
@@ -162,7 +173,7 @@ class Dokan_Invoice {
      * @return void
      */
     public function init_hooks() {
-        if ( ! class_exists( 'WPO_WCPDF' ) ) {
+        if ( ! class_exists( $this->wc_pdf_class ) ) {
             return ;
         }
 

--- a/dokan-invoice.php
+++ b/dokan-invoice.php
@@ -64,7 +64,7 @@ class Dokan_Invoice {
      *
      * @var string
      */
-	public $wc_pdf_class = '';
+    public $wc_pdf_class = '';
 
     /**
      * Constructor for the Dokan_Invoice class

--- a/dokan-invoice.php
+++ b/dokan-invoice.php
@@ -57,13 +57,13 @@ class Dokan_Invoice {
     private $depends_on       = array();
     private $dependency_error = array();
 
-	/**
-	 * WC PDF Plugin Class Name.
-	 *
-	 * @since 1.2.3
-	 *
-	 * @var string
-	 */
+    /**
+     * WC PDF Plugin Class Name.
+     *
+     * @since 1.2.3
+     *
+     * @var string
+     */
 	public $wc_pdf_class = '';
 
     /**

--- a/dokan-invoice.php
+++ b/dokan-invoice.php
@@ -10,6 +10,7 @@
  * Text Domain: dokan-invoice
  * WC requires at least: 5.0.0
  * WC tested up to: 8.1.0
+ * Requires Plugins: woocommerce, dokan-lite, woocommerce-pdf-invoices-packing-slips
  */
 
 /**
@@ -73,13 +74,13 @@ class Dokan_Invoice {
         self::$plugin_path     = trailingslashit( dirname( __FILE__ ) );
 
         $this->depends_on['dokan'] = array(
-            'name' => 'WeDevs_Dokan',
-            'notice'     => sprintf( __( '<b>Dokan PDF Invoice </b> requires %sDokan plugin%s to be installed & activated!' , 'dokan-invoice' ), '<a target="_blank" href="https://dokan.co/wordpress/">', '</a>' ),
+            'name'   => 'WeDevs_Dokan',
+            'notice' => sprintf( esc_html__( '<b>Dokan PDF Invoice </b> requires %sDokan plugin%s to be installed & activated!' , 'dokan-invoice' ), '<a target="_blank" href="https://dokan.co/wordpress/">', '</a>' ),
         );
 
         $this->depends_on['woocommerce_pdf_invoices'] = array(
-            'name' => 'WooCommerce_PDF_Invoices',
-            'notice'     => sprintf( __( '<b>Dokan PDF Invoice </b> requires %sWooCommerce PDF Invoices & packing slips plugin%s to be installed & activated!' , 'dokan-invoice' ), '<a target="_blank" href="https://wordpress.org/plugins/woocommerce-pdf-invoices-packing-slips/">', '</a>' ),
+            'name'   => 'WPO_WCPDF',
+            'notice' => sprintf( esc_html__( '<b>Dokan PDF Invoice </b> requires %sWooCommerce PDF Invoices & packing slips plugin%s to be installed & activated!' , 'dokan-invoice' ), '<a target="_blank" href="https://wordpress.org/plugins/woocommerce-pdf-invoices-packing-slips/">', '</a>' ),
         );
 
 	    add_action( 'before_woocommerce_init', [ $this, 'add_hpos_support' ] );
@@ -161,7 +162,7 @@ class Dokan_Invoice {
      * @return void
      */
     public function init_hooks() {
-        if ( ! class_exists( 'WooCommerce_PDF_Invoices' ) ) {
+        if ( ! class_exists( 'WPO_WCPDF' ) ) {
             return ;
         }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated plugin header to specify required plugins: WooCommerce, Dokan Lite, and WooCommerce PDF Invoices & Packing Slips.
  
- **Bug Fixes**
	- Improved dependency management by updating class references for better functionality related to PDF invoices.
  
- **Security Enhancements**
	- Enhanced security of localization strings in error notices by using `esc_html__()` for output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->